### PR TITLE
[Test] Create test-fail-notification.yaml

### DIFF
--- a/.github/workflows/test-fail-notification.yaml
+++ b/.github/workflows/test-fail-notification.yaml
@@ -1,0 +1,23 @@
+   
+name: Test Fail Notification
+
+on: [workflow_dispatch]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            # Send failure notification
+            - name: Notify failure
+              run: |
+                curl -X POST
+                'https://api.github.com/repos/ballerina-platform/ballerina-release/dispatches'\
+                -H 'Accept: application/vnd.github.v3+json'\
+                -H 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}'\
+                --data "{
+                  \"event_type\": \"notify-connector-failure\",
+                  \"client_payload\": {
+                    \"repoName\": \"module-ballerinax-microsoft.onenote\"
+                  }
+                }"
+                


### PR DESCRIPTION
# Description
This is a temporary test-work workflow to test the build failure notification.
After completing the test, we'll remove this

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
